### PR TITLE
Fix doom-zenburn.el typo

### DIFF
--- a/themes/doom-zenburn-theme.el
+++ b/themes/doom-zenburn-theme.el
@@ -304,9 +304,9 @@ Can be an integer to determine the exact padding."
    (helm-grep-lineno :foreground fg-1 :background bg)
    (helm-grep-match :foreground 'nil :background 'nil :inherit 'helm-match)
    (helm-grep-running :foreground red :background bg)
-   (helm-match :foreground orange :background base1 :weight bold)
+   (helm-match :foreground orange :background base1 :weight 'bold)
    (helm-swoop-target-line-face :foreground fg :background base6)
-   (helm-swoop-target-word-face :foreground yellow :background base6 :weight bold)
+   (helm-swoop-target-word-face :foreground yellow :background base6 :weight 'bold)
 
    ;; js2-mode
    (js2-jsdoc-tag :foreground green-2)


### PR DESCRIPTION
`doom-zenburn.el` file left out a single quote on two `:weight` attributes in the helm section. This fixes the typo and restores the theme's ability to be loaded and unloaded. Without the fix users cannot load new themes after loading doom-zenburn.